### PR TITLE
Update deprecated 'set-output' of GitHub Actions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,20 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout plugin source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
           path: bitergia-analytics-plugin
       - name: Get plugin metadata
         id: plugin_metadata
         run: |
-          echo "::set-output name=name::$(node -p "(require('./bitergia-analytics-plugin/package.json').name)")"
-          echo "::set-output name=version::$(node -p "(require('./bitergia-analytics-plugin/package.json').version).match(/[.0-9]+/)[0]")"
+          echo "name=$(node -p "(require('./bitergia-analytics-plugin/package.json').name)")" >> $GITHUB_OUTPUT
+          echo "version=$(node -p "(require('./bitergia-analytics-plugin/package.json').version).match(/[.0-9]+/)[0]")" >> $GITHUB_OUTPUT
       - name: Get OpenSearch Dashboards version
         id: osd_version
         run: |
-          echo "::set-output name=version::$(node -p "(require('./bitergia-analytics-plugin/opensearch_dashboards.json').opensearchDashboardsVersion).match(/[.0-9]+/)[0]")"
+          echo "version=$(node -p "(require('./bitergia-analytics-plugin/opensearch_dashboards.json').opensearchDashboardsVersion).match(/[.0-9]+/)[0]")" >> $GITHUB_OUTPUT
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ steps.osd_version.outputs.version }}
@@ -29,10 +29,10 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
-          echo "::set-output name=yarn_version::$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")"
+          echo "node_version=$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")" >> $GITHUB_OUTPUT
+          echo "yarn_version=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")" >> $GITHUB_OUTPUT
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # 3.6.0
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
       - name: Setup yarn


### PR DESCRIPTION
This PR updates the calls to 'set-output' using the new format to set outputs on the GitHub Actions workflows. More info in: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/