### PR TITLE
[ci] Fix typos in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout plugin source code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
         with:
-          path: plugin
+          path: bitergia-analytics-plugin
       - name: Get plugin metadata
         id: plugin_metadata
         run: |
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ steps.osd_version.outputs.version }}
-          path: osd
+          path: OpenSearch-Dashboards
       - name: Get node and yarn versions
         id: versions
         run: |
@@ -48,16 +48,16 @@ jobs:
           npm i -g yarn@${{ steps.versions.outputs.yarn_version }}
       - name: Move plugin to OpenSearch Dashboards folder
         run: |
-          mkdir -p osd/plugins
-          mv plugin osd/plugins
+          mkdir -p OpenSearch-Dashboards/plugins
+          mv bitergia-analytics-plugin OpenSearch-Dashboards/plugins
       - name: Bootstrap plugin/opensearch-dashboards
         run: |
-          cd osd/plugins/plugin
+          cd OpenSearch-Dashboards/plugins/bitergia-analytics-plugin
           yarn osd bootstrap
       - name: Build plugin
         id: build_zip
         run: |
-          cd osd/plugins/plugin
+          cd OpenSearch-Dashboards/plugins/bitergia-analytics-plugin
           yarn build
           tmp_zip_path=`ls $(pwd)/build/*.zip`
           filename=${{ steps.plugin_metadata.outputs.name }}-${{ steps.plugin_metadata.outputs.version }}_${{ steps.osd_version.outputs.version }}.zip


### PR DESCRIPTION
There were some typos in the filepaths that caused the workflow to fail.