### PR TITLE
Set GITHU_TOKEN permissions to upload packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,8 @@ jobs:
     name: Release plugin
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Get release tag
         id: tag


### PR DESCRIPTION
This change affects the 'release' workflow. Setting this permissions the workflow will be able to upload the JS package to GitHub.