### PR TITLE
Fix typo on action version for 'release' workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           path: plugin
       - name: Download plugin artifact
-        uses: actions/download-artifact@v29bc31d5ccc31df68ecc42ccf4149144866c47d8a # 3.0.2
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # 3.0.2
         with:
           name: plugin_artifact
           path: plugin/build


### PR DESCRIPTION
This commit fix an error on the release workflow.