### PR TITLE
Add compatibility for OpenSearch Dashboards 2.7.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "bitergiaAnalytics",
   "version": "0.2.0",
-  "opensearchDashboardsVersion": "2.6.0",
+  "opensearchDashboardsVersion": "2.7.0",
   "configPath": ["bitergia_analytics"],
   "requiredPlugins": ["navigation", "data", "opensearchDashboardsReact"],
   "optionalPlugins": ["share"],


### PR DESCRIPTION
Sets the OpenSearch Dashboards version to 2.7.0.