### PR TITLE
Hide "Switch Tenant" selector

### DIFF
--- a/public/index.scss
+++ b/public/index.scss
@@ -93,6 +93,7 @@ a.logoContainer {
 
 .hide-tenant-selector {
   [data-test-subj="switch-tenants"],
+  [data-test-subj="switch-tenants"] + hr,
   [data-test-subj="switch-tenants"] + div hr {
     display: none;
   }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -101,8 +101,8 @@ export class BitergiaAnalyticsPlugin
 
     this.changeBranding(branding);
 
-    // Hide tenant selector for anonymous users in user menu
-    this.hideAnonymousTenants(core.http);
+    // Hide tenant selector in user menu
+    document.body.classList.add('hide-tenant-selector');
 
     // Hide popup tenant selector for all users
     sessionStorage.setItem('opendistro::security::tenant::show_popup', 'false');
@@ -182,20 +182,5 @@ export class BitergiaAnalyticsPlugin
     }
 
     return tenant;
-  }
-
-  private async hideAnonymousTenants(httpClient) {
-    try {
-      const res = await httpClient.fetch('/api/v1/configuration/account');
-
-      if (
-        res.data.user_name &&
-        res.data.user_name === 'opendistro_security_anonymous'
-      ) {
-        document.body.classList.add('hide-tenant-selector');
-      }
-    } catch (error) {
-      console.log(`Error fetching user: ${error}`);
-    }
   }
 }


### PR DESCRIPTION
Hides the "Switch tenant" selector for all users.
Closes #34.