### PR TITLE
Add configuration option to show/hide tenant selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ curl -X PUT <OSD URL>/_plugins/_bap/menu \
 }'
 ```
 
+## Configuration
+
+### Hide tenant selector
+
+To hide or show the `Switch tenants` button on the user menu, add the configuration
+property `bitergia_analytics.hideTenantSelector` to the `opensearch_dashboards.yml`
+file and set the value to either `true` or `false`. The selector is hidden by
+default.
+
 ## License
 
 This project is licensed under Apache 2.0. See the [LICENSE](./LICENSE) file

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -70,7 +70,10 @@ export class BitergiaAnalyticsPlugin
 
   public async start(core: CoreStart): BitergiaAnalyticsPluginStart {
     // Get branding from opensearch_dashboards.yml
-    const { branding } = this.initializerContext.config.get();
+    const {
+      branding,
+      hideTenantSelector,
+    } = this.initializerContext.config.get();
     const baseURL = core.application.getUrlForApp('dashboards');
     const tenant = await this.getTenant(core.http);
 
@@ -102,7 +105,9 @@ export class BitergiaAnalyticsPlugin
     this.changeBranding(branding);
 
     // Hide tenant selector in user menu
-    document.body.classList.add('hide-tenant-selector');
+    if (hideTenantSelector) {
+      document.body.classList.add('hide-tenant-selector');
+    }
 
     // Hide popup tenant selector for all users
     sessionStorage.setItem('opendistro::security::tenant::show_popup', 'false');

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import { BitergiaAnalyticsPlugin } from './plugin';
 export const config = {
   exposeToBrowser: {
     branding: true,
+    hideTenantSelector: true,
   },
   schema: schema.object({
     branding: schema.object({
@@ -36,6 +37,7 @@ export const config = {
       dropdownColor: schema.string({ defaultValue: '#525252' }),
       projectName: schema.string({ defaultValue: 'Bitergia Analytics' }),
     }),
+    hideTenantSelector: schema.boolean({ defaultValue: true }),
   }),
 };
 


### PR DESCRIPTION
Adds the `bitergia_analytics.hideTenantSelector` configuration option to `opensearch_dashboards.yml` to hide or show the tenant selector on the user menu.