### PR TITLE
Set OpenSearch Dashboards version to 2.10

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "bitergiaAnalytics",
   "version": "0.14.0",
-  "opensearchDashboardsVersion": "2.7.0",
+  "opensearchDashboardsVersion": "2.10.0",
   "configPath": [
     "bitergia_analytics"
   ],

--- a/releases/unreleased/set-opensearch-dashboards-version-to-210.yml
+++ b/releases/unreleased/set-opensearch-dashboards-version-to-210.yml
@@ -1,0 +1,8 @@
+---
+title: Set OpenSearch Dashboards version to 2.10
+category: dependency
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The plugin is updated to use the latest compatible
+  OpenSearch Dashboards version.


### PR DESCRIPTION
This commit updates the build target to OpenSearch 2.10.