### PR TITLE
Fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bitergia_analytics",
+  "name": "bitergia-analytics-plugin",
   "version": "0.14.1-rc.1",
   "description": "Bitergia Analytics Plugin",
   "license": "Apache-2.0",


### PR DESCRIPTION
The release workflow expects the name to be `bitergia-analytics-plugin` when building the plugin.