### PR TITLE
Replace anonymous user icon with login button

### DIFF
--- a/public/components/loginButton.tsx
+++ b/public/components/loginButton.tsx
@@ -1,6 +1,5 @@
 /*
- * Copyright 2021-2022 Bitergia
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021-2023 Bitergia
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -14,14 +13,9 @@
  * permissions and limitations under the License.
  */
 
-import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import React from 'react';
+import { EuiButtonEmpty } from '@elastic/eui';
 
-export interface AppPluginStartDependencies {
-  navigation: NavigationPublicPluginStart;
-}
-
-export interface AccountInfo {
-  user_name?: string;
-  user_requested_tenant?: string;
-  roles?: string[];
-}
+export const LoginButton = ({ url }) => {
+  return <EuiButtonEmpty href={url} aria-label="Log in" iconType="push" />;
+};

--- a/public/index.scss
+++ b/public/index.scss
@@ -98,3 +98,9 @@ a.logoContainer {
     display: none;
   }
 }
+
+.hide-anonymous-user {
+  #user-icon-btn {
+    display: none;
+  }
+}

--- a/public/tests/plugin.test.ts
+++ b/public/tests/plugin.test.ts
@@ -20,6 +20,7 @@ import {
   menuMock,
   initializerContextMock,
   coreServicesMock,
+  coreSetupMock,
   mountParamsMock,
 } from '../../test/mocks';
 import { API_PREFIX } from '../../common';
@@ -27,6 +28,7 @@ import { API_PREFIX } from '../../common';
 describe('Plugin setup', () => {
   const apiURL = `${API_PREFIX}/menu`;
   const plugin = new BitergiaAnalyticsPlugin(initializerContextMock);
+  plugin.setup(coreSetupMock);
 
   it('Registers menu', async () => {
     const core = await plugin.start(coreServicesMock);
@@ -41,6 +43,20 @@ describe('Plugin setup', () => {
     // Registers menu
     expect(
       coreServicesMock.chrome.navControls.registerExpandedRight
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('Registers login button', async () => {
+    await plugin.start(coreServicesMock);
+
+    expect(plugin.accountInfo).toEqual({
+      user_name: 'opendistro_security_anonymous',
+      user_requested_tenant: 'test_tenant',
+      roles: ['bap_plugins_visibility'],
+    });
+
+    expect(
+      coreServicesMock.chrome.navControls.registerRight
     ).toHaveBeenCalledTimes(1);
   });
 

--- a/releases/unreleased/login-button-for-anonymous-users.yml
+++ b/releases/unreleased/login-button-for-anonymous-users.yml
@@ -1,0 +1,8 @@
+---
+title: Login button for anonymous users
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  The header now includes a login button in public dashboards,
+  replacing the anonymous user icon.

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -59,12 +59,20 @@ const coreServicesMock = {
     navControls: {
       registerExpandedCenter: jest.fn(),
       registerExpandedRight: jest.fn(),
+      registerRight: jest.fn(),
     },
     setBreadcrumbs: jest.fn(),
   },
   http: {
     fetch: jest.fn().mockResolvedValue({
       data: menuMock,
+    }),
+    get: jest.fn().mockResolvedValue({
+      data: {
+        user_name: 'opendistro_security_anonymous',
+        user_requested_tenant: 'test_tenant',
+        roles: ['bap_plugins_visibility'],
+      },
     }),
     put: jest.fn().mockResolvedValue({
       hits: [
@@ -77,6 +85,22 @@ const coreServicesMock = {
           _id: '12345',
         },
       ],
+    }),
+  },
+};
+
+const coreSetupMock = {
+  application: {
+    register: jest.fn(),
+    registerAppUpdater: jest.fn(),
+  },
+  http: {
+    get: jest.fn().mockResolvedValue({
+      data: {
+        user_name: 'opendistro_security_anonymous',
+        user_requested_tenant: 'test_tenant',
+        roles: ['bap_plugins_visibility'],
+      },
     }),
   },
 };
@@ -94,6 +118,7 @@ export {
   menuMock,
   initializerContextMock,
   coreServicesMock,
+  coreSetupMock,
   mountParamsMock,
   historyMock,
 };


### PR DESCRIPTION
Hides the user icon if the user is 'opendistro_security_anonymous' and adds a button that links to the login page on the header. Removes the API call to get the tenant since it can be gathered from the account info.