### PR TITLE
Update OpenSearch Dashboards version to 3.2.0

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -46,6 +46,11 @@ jobs:
           YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
           echo "Installing yarn @$YARN_VERSION"
           npm i -g yarn@$YARN_VERSION
+      - name: Setup Java
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: Move plugin to OpenSearch Dashboards folder
         run: |
           mkdir -p OpenSearch-Dashboards/plugins

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "bitergiaAnalytics",
   "version": "0.33.0-rc.3",
-  "opensearchDashboardsVersion": "2.16.0",
+  "opensearchDashboardsVersion": "3.2.0",
   "configPath": [
     "bitergia_analytics"
   ],

--- a/releases/unreleased/plugin-compability-for-opensearch-dashboards-320.yml
+++ b/releases/unreleased/plugin-compability-for-opensearch-dashboards-320.yml
@@ -1,0 +1,7 @@
+---
+title: Upgrade to OpenSearch Dashboards 3.2.0
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Upgrade plugin compatibility with OpenSearch Dashboards 3.2.0.


### PR DESCRIPTION
This change updates the version of OpenSearch Dashboards to 3.2.0. This is necessary to ensure compatibility with new features and improvements in the latest release.

Include Java 21 in tests; otherwise, it fails to run `yarn osd bootstrap`