### PR TITLE
Fix navigation with pinned filters

### DIFF
--- a/public/components/dropdown.tsx
+++ b/public/components/dropdown.tsx
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   EuiHeaderLink,
   EuiPopover,

--- a/public/components/link.tsx
+++ b/public/components/link.tsx
@@ -16,12 +16,25 @@
 import React from 'react';
 import { EuiHeaderLink } from '@elastic/eui';
 
-export const Link = ({ item, baseURL }) => {
+export const Link = ({ item, baseURL, navigateToUrl }) => {
   const url = item.dashboard_id?.includes('http')
     ? item.dashboard_id
     : `${baseURL}#/view/${item.dashboard_id}`;
+
+  const isLeftClickEvent = (event: React.MouseEvent) => {
+    return event.button === 0;
+  };
+
+  const navigateToLink = (event: React.MouseEvent) => {
+    if (isLeftClickEvent(event)) {
+      event.preventDefault();
+      navigateToUrl(url);
+    }
+    return;
+  };
+
   return (
-    <EuiHeaderLink href={url} isActive={item.isActive}>
+    <EuiHeaderLink href={url} isActive={item.isActive} onClick={navigateToLink}>
       {item.name}
     </EuiHeaderLink>
   );

--- a/public/components/menu.tsx
+++ b/public/components/menu.tsx
@@ -15,13 +15,12 @@
 
 import React, { useState, useEffect } from 'react';
 import { EuiHeaderLinks } from '@elastic/eui';
-import { Link } from './link.tsx';
-import { Dropdown } from './dropdown.tsx';
+import { Link } from './link';
+import { Dropdown } from './dropdown';
 
 export const Menu = (props) => {
   const [menu, setMenu] = useState(props.menu);
-  const { baseURL, history } = props;
-
+  const { baseURL, history, navigateToUrl } = props;
   function setActiveLink() {
     let updated = menu;
 
@@ -37,7 +36,7 @@ export const Menu = (props) => {
           });
         }
         return Object.assign(dashboard, {
-          isActive: dashboard.dashboards.some(
+          isActive: dashboard.dashboards?.some(
             (d) => currentDashboard === d.dashboard_id
           ),
         });
@@ -57,8 +56,8 @@ export const Menu = (props) => {
 
     // Add class to parent container
     const menuBar = document.querySelector('.bitergia-menu');
-    const parent = menuBar.closest('.euiHeaderSectionItem').parentElement;
-    parent.classList.add('bitergia-menu-parent');
+    const parent = menuBar?.closest('.euiHeaderSectionItem')?.parentElement;
+    parent?.classList.add('bitergia-menu-parent');
   }, []);
 
   useEffect(() => {
@@ -69,9 +68,14 @@ export const Menu = (props) => {
 
   return (
     <EuiHeaderLinks gutterSize="xs" className="bitergia-menu">
-      {menu.map((link, index) =>
+      {menu.map((link, index: number) =>
         link.type === 'entry' ? (
-          <Link item={link} baseURL={baseURL} key={index} />
+          <Link
+            item={link}
+            baseURL={baseURL}
+            key={index}
+            navigateToUrl={navigateToUrl}
+          />
         ) : (
           <Dropdown item={link} baseURL={baseURL} key={index} />
         )

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -121,7 +121,13 @@ export class BitergiaAnalyticsPlugin {
       if (Array.isArray(menuItems)) {
         core.chrome.navControls.registerExpandedRight({
           order: 2,
-          mount: (target) => this.mountMenu(menuItems, baseURL, target),
+          mount: (target) =>
+            this.mountMenu(
+              menuItems,
+              baseURL,
+              target,
+              core.application.navigateToUrl
+            ),
         });
       } else {
         console.error('Error loading menu: invalid menu data');
@@ -158,12 +164,17 @@ export class BitergiaAnalyticsPlugin {
 
   public stop() {}
 
-  private mountMenu(menu, baseURL, targetDomElement) {
+  private mountMenu(menu, baseURL, targetDomElement, navigateToUrl) {
     // Initialize router history to know which route is active
     const history = createBrowserHistory();
 
     ReactDOM.render(
-      <Menu menu={menu} baseURL={baseURL} history={history} />,
+      <Menu
+        menu={menu}
+        baseURL={baseURL}
+        history={history}
+        navigateToUrl={navigateToUrl}
+      />,
       targetDomElement
     );
     return () => ReactDOM.unmountComponentAtNode(targetDomElement);

--- a/releases/unreleased/menu-navigation-unpinned-filters.yml
+++ b/releases/unreleased/menu-navigation-unpinned-filters.yml
@@ -1,0 +1,8 @@
+---
+title: Menu navigation unpinned filters
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+ The menu links didn't keep the pinned filters when navigating
+ from some URLs.


### PR DESCRIPTION
This PR fixes an issue with the menu links not maintaining the pinned filters when navigating from a URL that doesn't include them (security, dashboards management, etc.)